### PR TITLE
Invalid words

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,12 +1,12 @@
 class Search
   def self.find_word(word)
     response = OedService.find_word(word)
-    self.verify_response_status(response)
+    self.determine_response_status(response)
   end
 
   private
 
-  def self.verify_response_status(response)
+  def self.determine_response_status(response)
     if response.status == 404
       nil
     elsif response.status == 200

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,8 +1,12 @@
 class Search
   def self.find_word(word)
     response = OedService.find_word(word)
-    res = JSON.parse(response.body)
-    self.build_defs(res)
+    if response.status == 404
+      nil
+    elsif response.status == 200
+      res = JSON.parse(response.body)
+      self.build_defs(res)
+    end
   end
 
   private

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,6 +1,12 @@
 class Search
   def self.find_word(word)
     response = OedService.find_word(word)
+    self.verify_response_status(response)
+  end
+
+  private
+
+  def self.verify_response_status(response)
     if response.status == 404
       nil
     elsif response.status == 200
@@ -8,8 +14,6 @@ class Search
       self.build_defs(res)
     end
   end
-
-  private
 
   def self.build_defs(res)
     self.parse_results(res).flatten.compact

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,8 +1,10 @@
-<h1><%= @word %> exists!</h1>
+<% if @definitions %>
+  <h1><%= @word %> exists!</h1>
 
-<h3>Definitions: </h3>
-<ol>
-  <% @definitions.each do |definition| %>
-    <li><%= definition %></li>
-  <% end %>
-</ol>
+  <h3>Definitions: </h3>
+  <ol>
+    <% @definitions.each do |definition| %>
+      <li><%= definition %></li>
+    <% end %>
+  </ol>
+<% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -7,4 +7,6 @@
       <li><%= definition %></li>
     <% end %>
   </ol>
+<% else %>
+  <h1><%= @word %> does not exist.</h1>
 <% end %>

--- a/spec/features/page_load_spec.rb
+++ b/spec/features/page_load_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe('a use can access the welcome page') do
       visit '/'
       fill_in :search, with: 'arstoien'
       click_on "Submit"
+      expect(page).to_not have_content 'arstoien exists'
       expect(page).to have_content 'arstoien does not exist'
     end
   end

--- a/spec/features/page_load_spec.rb
+++ b/spec/features/page_load_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe('a use can access the welcome page') do
-  it('a user can search for a word to see if it is valid') do
+  it('a user can find definitions of valid words') do
     VCR.use_cassette('verify_results') do
       # as a user
       # when I visit /
@@ -18,6 +18,15 @@ RSpec.describe('a use can access the welcome page') do
       expect(page).to have_content "best exists"
       # and I should see a definition for best
       expect(page).to have_content "Definitions: "
+    end
+  end
+
+  it 'a user gets an error for an invalid word' do
+    VCR.use_cassette('invalid_word_search') do
+      visit '/'
+      fill_in :search, with: 'arstoien'
+      click_on "Submit"
+      expect(page).to have_content 'arstoien does not exist'
     end
   end
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -105,7 +105,12 @@ RSpec.describe Search do
     end
 
     it 'returns nil for a response status of 404' do
-
+      VCR.use_cassette 'determine_response_status_404' do
+        response = OedService.find_word("arstoien")
+        defs = Search.determine_response_status(response)
+        expect(response.status).to eq 404
+        expect(defs).to eq nil
+      end
     end
   end
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -92,4 +92,20 @@ RSpec.describe Search do
       expect(defs.count).to eq 2
     end
   end
+
+  context '.determine_response_status' do
+    it 'returns definitions for a response status of 200' do
+      VCR.use_cassette 'determine_response_status_200' do
+        response = OedService.find_word("word")
+        defs = Search.determine_response_status(response)
+        expect(response.status).to eq 200
+        expect(defs).to be_a Array
+        expect(defs.first).to be_a String
+      end
+    end
+
+    it 'returns nil for a response status of 404' do
+
+    end
+  end
 end


### PR DESCRIPTION
writes test for returning 'word does not exist' for invalid words
updates .find_word to use API response status to set the definitions of invalid words to nil
if the definitions are nil, then the page displays 'word does not exist'